### PR TITLE
fix: Save Request

### DIFF
--- a/src/screenshotdisplay.cpp
+++ b/src/screenshotdisplay.cpp
@@ -367,7 +367,8 @@ void ScreenshotDisplay::onSaveRequested() {
     QString filePath = QFileDialog::getSaveFileName(this, "Save As", defaultFileName, fileFilter);
 
     if (!filePath.isEmpty()) {
-        originalPixmap.save(filePath);
+        QPixmap selectedPixmap = originalPixmap.copy(selectionRect);
+        selectedPixmap.save(filePath);
         close();
     }
 }


### PR DESCRIPTION
The error that saved result doesn't match selected region and keeps saving a whole screen shot.